### PR TITLE
Add readout and display of fan speeds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ packages=find:
 install_requires =
     odin-control @ git+https://github.com/odin-detector/odin-control@1.4.0#egg=odin-control
     smbus2
+    Adafruit_BBIO
 
 [options.packages.find]
 where=src
@@ -22,6 +23,7 @@ test =
     flake8
     flake8-docstrings
     isort
+    mypy
 
 [versioneer]
 VCS = git
@@ -33,5 +35,8 @@ tag_prefix=
 [flake8]
 max-line-length = 100
 extend-ignore = E203, W503
+
+[mypy]
+ignore_missing_imports = True
 
 

--- a/src/pscusolo/controller.py
+++ b/src/pscusolo/controller.py
@@ -27,6 +27,8 @@ class PSCUSoloController():
         self.param_tree = ParameterTree({
             "overall": (lambda: self.pscu.overall, None),
             "latched": (lambda: self.pscu.latched, None),
+            "armed": (lambda: self.pscu.armed, self.pscu.set_armed),
+            "tripped": (lambda: self.pscu.tripped, None),
             "temperature": {
                 "healthy": (lambda: self.pscu.temp_healthy, None),
                 "latched": (lambda: self.pscu.temp_latched, None),
@@ -83,15 +85,22 @@ class PSCUSoloController():
                         "pump_trip": (lambda: self.pscu.pump_trip, None),
                     }
                 ]
-
             },
-            "armed": (lambda: self.pscu.armed, self.pscu.set_armed),
-            "tripped": (lambda: self.pscu.tripped, None),
+            "fans": {
+                "sensors": [
+                    {
+                        "sensor_name": "Fan 1",
+                        "value": (lambda: self.pscu.fans[0].rpm_5, None),
+                    },
+                    {
+                        "sensor_name": "Fan 2",
+                        "value": (lambda: self.pscu.fans[1].rpm_5, None),
+                    },
+                ]
+            }
         })
 
-        self.update_task = PeriodicCallback(  # loop do-update every 250ms
-            self.do_update, 250
-        )
+        self.update_task = PeriodicCallback(self.do_update, 250)
         self.update_task.start()
 
     def get(self, path):

--- a/src/pscusolo/gpio_fan_speed.py
+++ b/src/pscusolo/gpio_fan_speed.py
@@ -1,0 +1,177 @@
+"""GPIO fan speed measurement for the PSCUsolo.
+
+This module implements classes to measure PSCUsolo fan speeds via GPIO input pins connected to the
+tachometer output of the fan. This is implemented via the event detection mechanism provided by the
+Adafruit_BBIO GPIO class. A callback counts rising edges on the tacho input - a periodic call to
+the update() method calculates the the instantaneous and rolling mean freqeuency of the pulese.
+Methods convert these to RPM assuming the typical 2 tacho pulses per revolution.
+
+Tim Nicholls, STFC Detector System Software Group
+"""
+import time
+from collections import deque
+from typing import Optional
+
+import Adafruit_BBIO.GPIO as GPIO
+
+
+class RollingMean(deque):
+    """Simple rolling mean class.
+
+    This class implements a simple rolling mean calculation for a specified number of samples.
+    Based on the standard deque, new values can simply be append()-ed to the object, and the mean
+    is calculated based on the number of samples held, i.e. is valid for the first n samples before
+    the deque is filled. Successive append() calls will remove the oldest value from the deque.
+    """
+
+    def __init__(self, maxlen: int):
+        """Initialise the rolling mean.
+
+        This constructor initialises a rolling mean object of the specified length.
+
+        :param maxlen: maximum length of the rolling mean.
+        """
+        super().__init__([], maxlen=maxlen)
+
+    @property
+    def mean(self):
+        """Return the current rolling mean.
+
+        This property method calculates and returns the current mean of the values held in the
+        object. If no values have been appended, the mean is returned as zero.
+
+        :return: mean of the current values in the object
+        """
+        mean = 0.0
+        if len(self):
+            mean = float(sum(self)) / len(self)
+
+        return mean
+
+
+class GpioFanSpeed:
+    """GPIO fan speed measurement class.
+
+    This class implements measurement of fan speeds via GPIO pins connected to the tachometer
+    output of fans.
+    """
+
+    def __init__(
+        self,
+        tach_pin: str,
+        pwm_pin: Optional[str] = None,
+        edge: int = GPIO.RISING,
+    ):
+        """Initialise the GPIO fan speed object.
+
+        This constructor initialises the GPIO fan speed object. The specified tacho GPIO pin is
+        configured as an input and for edge detection. If a PWM pin is specified that is set up as
+        desired.
+
+        :param tach_pin : fan tachometer GPIO pin name (using Adafruit_BBIO naming convention)
+        :param pwm_pin : optional fan PWM control GPIO pin name
+        :param edge : optional edge to detec, defaults to rising edge
+        """
+        self.tach_pin = tach_pin
+        self.pwm_pin = pwm_pin
+
+        # Initialise state of internal counters
+        self.event_count = 0
+        self.last_count = 0
+        self.delta = 0
+        self.last_time: Optional[float] = None
+
+        # Initialise frequency variables
+        self.freq_1 = 0.0
+        self.freq_5 = RollingMean(5)
+        self.freq_10 = RollingMean(10)
+
+        # If the PWM pin is specified, enable it as an output. For now set the initial default value
+        # to high.
+        if self.pwm_pin:
+            GPIO.setup(self.pwm_pin, GPIO.OUT, initial=GPIO.HIGH)
+
+        # Set up the tacho pin as an input and add edge event detection
+        GPIO.setup(self.tach_pin, GPIO.IN)
+        GPIO.add_event_detect(self.tach_pin, edge, self._callback)
+
+    def _callback(self, _: str) -> None:
+        """Call back on edge event detection.
+
+        This method is called back when an edge detection event occurs on the tacho pin. The
+        event counter is simply incremented.
+
+        :param _ : unused channel argument required by the GPIO callback mechanism
+        """
+        self.event_count += 1
+
+    def update(self) -> None:
+        """Update fan speed calculations.
+
+        This method should be called periodically, e.g. by a background update loop in an adapter,
+        to update current fan speed readings. Based on the event counter, this calculates and stores
+        the current fan frequency (in Hz) and appends the value to the rolling 5- and 10-sample
+        means.
+        """
+        # Copy the current count locally for consistency and save the current time
+        current_count = self.event_count
+        now = time.time()
+
+        # Calculate the event count delta
+        self.delta = current_count - self.last_count
+
+        # If a previous update has been done, calculate and store the frequency and append to the
+        # rolling means.
+        if self.last_time:
+            self.freq_1 = self.delta / (now - self.last_time)
+            self.freq_5.append(self.freq_1)
+            self.freq_10.append(self.freq_1)
+
+        # Store the last count and time
+        self.last_count = current_count
+        self.last_time = now
+
+    @staticmethod
+    def freq_to_rpm(freq: float) -> int:
+        """Convert frequency to RPM.
+
+        This static method converts a frequency measurement into RPM, assuming the standard two
+        pulses per revolution operation of the fan.
+
+        :param freq: frequency to convert
+        :return: integer RPM value
+        """
+        return int(freq * 30)
+
+    @property
+    def rpm(self) -> int:
+        """Return the current fan speed in RPM.
+
+        This property method returns the current fan speed as RPM. The value is rounded to integer
+        to remove the pulse sampling quantisation.
+
+        :return current fan speed in RPM
+        """
+        return self.freq_to_rpm(self.freq_1)
+
+    @property
+    def rpm_5(self) -> int:
+        """Return the current 5-sample rolling mean fan speed in RPM.
+
+        This property method returns the current fan speed as RPM from the 5-sample rolling mean.
+        The value is rounded to integer to remove the pulse sampling quantisation.
+
+        :return current 5-sample rolling average fan speed in RPM
+        """
+        return self.freq_to_rpm(self.freq_5.mean)
+
+    @property
+    def rpm_10(self) -> int:
+        """Return the current 10-sample rolling mean fan speed in RPM.
+
+        This property method returns the current fan speed as RPM from the 10-sample rolling mean.
+        The value is rounded to integer to remove the pulse sampling quantisation.
+
+        :return current 10-sample rolling average fan speed in RPM
+        """
+        return self.freq_to_rpm(self.freq_10.mean)

--- a/test/static/index.html
+++ b/test/static/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <title>ODIN Server</title>
+    <title>PSCU Solo</title>
 
     <!-- Bootstrap -->
     <link href="js/bootstrap-3.3.6-dist/css/bootstrap.min.css" rel="stylesheet">
@@ -47,12 +47,20 @@
 							<div id="overall-latched" class="col-xs-5 status vertical-align">&nbsp;</div>
 						</div>
 						<div class="row sidebar-row vertical-align">
+							<div class="col-xs-7">Tripped:</div>
+							<div id="overall-tripped" class="col-xs-5 status vertical-align">&nbsp;</div>
+						</div>
+						<div class="row sidebar-row vertical-align">
 							<div class="col-xs-7">Armed:</div>
 							<div id="overall-armed" class="col-xs-5 status vertical-align">&nbsp;</div>
 						</div>
 						<div class="row sidebar-row vertical-align">
-							<div class="col-xs-7">Tripped:</div>
-							<div id="overall-tripped" class="col-xs-5 status vertical-align">&nbsp;</div>
+							<div class="col-xs-7">Fan 1:</div>
+							<div id="overall-fan1" class="col-xs-5 vertical-align">&nbsp;</div>
+						</div>
+						<div class="row sidebar-row vertical-align">
+							<div class="col-xs-7">Fan 2:</div>
+							<div id="overall-fan2" class="col-xs-5 vertical-align">&nbsp;</div>
 						</div>
 						<div class="row sidebar-title">
 							<h3>Actions</h3>

--- a/test/static/js/pscusolo.js
+++ b/test/static/js/pscusolo.js
@@ -299,7 +299,7 @@ var pscusolo_html = "";
 
 pscusolo_html += generateTempSensors(2);
 pscusolo_html += generateHumiditySensors(1);
-pscusolo_html += generateLeakSensors(1)
+pscusolo_html += generateLeakSensors(1);
 pscusolo_html += generatePumpSensors(1);
 
 $("#pscusolo").html(pscusolo_html);
@@ -307,6 +307,7 @@ $("#pscusolo").html(pscusolo_html);
 var temp_sensors = [];
 var humidity_sensors = [];
 var leak_sensors = [];
+var fan_sensors = []
 var pump_sensor;
 
 var global_elems = new Map();
@@ -317,7 +318,8 @@ $(document).ready(function() {
         temp_sensors.push(new TempSensor(i));
     for(var i = 0; i < 1; ++i)
         humidity_sensors.push(new HumiditySensor(i));
-        for(var i = 0; i < 1; ++i)
+
+    for(var i = 0; i < 1; ++i)
         leak_sensors.push(new LeakSensor(i));
 
     pump_sensor = new PumpSensor(0);
@@ -336,9 +338,9 @@ $(document).ready(function() {
     global_elems.set("overall-latched", document.querySelector("#overall-latched"));
     global_elems.set("overall-tripped", document.querySelector("#overall-tripped"));
     global_elems.set("overall-armed", document.querySelector("#overall-armed"));
+    global_elems.set("overall-fan1", document.querySelector("#overall-fan1"));
+    global_elems.set("overall-fan2", document.querySelector("#overall-fan2"));
     global_elems.set("arm", document.querySelector("#button-arm"));
-
-
 
     //Start update function
     setInterval(updateAll, 500);
@@ -369,14 +371,20 @@ function updateAll()
         for(var i = 0; i < humidity_sensors.length; ++i)
             humidity_sensors[i].update(response.humidity.sensors[i]);
 
-         for(var i = 0; i < leak_sensors.length; ++i)
-              leak_sensors[i].update(response.leak.sensors[i]);
+        for(var i = 0; i < leak_sensors.length; ++i)
+            leak_sensors[i].update(response.leak.sensors[i]);
+
+        for(var i = 0; i < fan_sensors.length; ++i)
+            fan_sensors[i].update(response.fans.sensors[i])
 
         //Handle overall status
         update_status_box(global_elems.get("overall-status"), response.overall, 'Healthy', 'Error');
         update_status_box(global_elems.get("overall-latched"), !response.latched, 'No', 'Yes');
         update_status_box(global_elems.get("overall-tripped"), !response.tripped, 'No', 'Yes');
         update_status_box(global_elems.get("overall-armed"), response.armed, 'Yes', 'No');
+
+        global_elems.get("overall-fan1").innerHTML = response.fans.sensors[0].value + "&nbsp;rpm";
+        global_elems.get("overall-fan2").innerHTML = response.fans.sensors[1].value + "&nbsp;rpm";
 
         // Handle health states
         update_status_box(global_elems.get("tmp-health"), response.temperature.healthy, 'Healthy', 'Error');


### PR DESCRIPTION
The PSCUsolo exposes two 4-pin fan headers on the PCB. The PWM and tacho pins of those headers are connected to GPIO pins on the BBB. This PR implements readout and display of the fan speeds in the PSCUsolo adapter and UI